### PR TITLE
add dsl syntax with commands: before; after; configuration; visit_to; 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,12 @@
-sudo: false
 language: ruby
+dist: trusty
+sudo: required
+cache: bundler
+bundler_args: --without console
+script:
+  - bundle exec rake spec
 rvm:
-  - 2.3.0
-before_install: gem install bundler -v 1.12.5
+  - 2.3.8
+  - 2.4.5
+  - 2.5.3
+  - 2.6.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ cache: bundler
 bundler_args: --without console
 script:
   - bundle exec rake spec
+addons:
+  chrome: stable
 rvm:
   - 2.3.8
   - 2.4.5

--- a/crawler.gemspec
+++ b/crawler.gemspec
@@ -33,10 +33,10 @@ Gem::Specification.new do |spec|
   spec.add_dependency "activesupport", '~> 5.2', '>= 5.2.2'
   spec.add_dependency "chromedriver-helper", '~> 2.1', '>= 2.1.0'
   spec.add_dependency "selenium-webdriver", '~> 3.141', '>= 3.141.0'
-
+  spec.add_dependency "dsl_organizer", '~> 1.0.0'
 
   spec.add_development_dependency "bundler", "~> 1.17.2", '>= 1.17.2'
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
-  spec.add_development_dependency "pry-byebug", "~> 3.5.1", '>= 3.5.1'
+  spec.add_development_dependency "byebug", "~> 11.0.0"
 end

--- a/examples/example1/parse_rwpod.rb
+++ b/examples/example1/parse_rwpod.rb
@@ -1,0 +1,17 @@
+require_relative '../../lib/crawler'
+
+Crawler.run do
+  configuration do |conf|
+    conf.max_pages 10
+  end
+
+  before :all do
+    visit_to 'https://www.epam.com/'
+    within('.top-navigation-ui') do
+      click_on 'Careers'
+    end
+    page.find('h2' ,text:'Find your dream job')
+  end
+
+  extract_links_for('https://www.rwpod.com/')
+end

--- a/lib/crawler.rb
+++ b/lib/crawler.rb
@@ -1,5 +1,14 @@
+require 'dsl_organizer'
 require "crawler/version"
+require 'capybara'
+
+require 'crawler/dsl/configuration'
+require 'crawler/dsl/hooks/after_hook'
+require 'crawler/dsl/hooks/before_hook'
+require 'crawler/dsl/link_extractor'
+require 'crawler/dsl/visit_command'
 require 'crawler/options'
+require 'crawler/hooks_operator'
 require 'crawler/engine'
 
 require 'crawler/followups/screenshots_indexer'
@@ -8,5 +17,11 @@ require 'crawler/followups/wraith_integrator'
 # Crawls web site and extracts links available.
 
 module Crawler
-  # Your code goes here...
+  include DslOrganizer.dictionary(commands: [
+      :after,
+      :before,
+      :configuration,
+      :extract_links_for,
+      :visit_to
+  ])
 end

--- a/lib/crawler/dsl/configuration.rb
+++ b/lib/crawler/dsl/configuration.rb
@@ -1,0 +1,28 @@
+module Crawler
+  module Dsl
+    class Configuration
+      include DslOrganizer::ExportCommand[:configuration]
+
+      OPTIONS = [:screenshots_path, :max_pages, :window_width, :window_height]
+
+      DEFAULT_OPTIONS = {
+          window_width: 1280,
+          window_height: 1600
+      }
+
+      def call
+        yield(self)
+      end
+
+      def options
+        @options ||= DEFAULT_OPTIONS
+      end
+
+      OPTIONS.each do |option|
+        define_method option do |value|
+          options[option] = value
+        end
+      end
+    end
+  end
+end

--- a/lib/crawler/dsl/hooks/after_hook.rb
+++ b/lib/crawler/dsl/hooks/after_hook.rb
@@ -1,0 +1,23 @@
+require 'dsl_organizer/export_command'
+
+module Crawler
+  module Dsl
+    module Hooks
+      class AfterHook
+        include DslOrganizer::ExportCommand[:after]
+
+        def call(type, &block)
+          hook_type = type.nil? ? :all : type.to_sym
+          hooks[hook_type].unshift(block)
+        end
+
+        def hooks
+          @hooks ||= {
+              all: [],
+              each: []
+          }
+        end
+      end
+    end
+  end
+end

--- a/lib/crawler/dsl/hooks/before_hook.rb
+++ b/lib/crawler/dsl/hooks/before_hook.rb
@@ -1,0 +1,21 @@
+module Crawler
+  module Dsl
+    module Hooks
+      class BeforeHook
+        include DslOrganizer::ExportCommand[:before]
+
+        def call(type, &block)
+          hook_type = type.nil? ? :all : type.to_sym
+          hooks[hook_type].push(block)
+        end
+
+        def hooks
+          @hooks ||= {
+              all: [],
+              each: []
+          }
+        end
+      end
+    end
+  end
+end

--- a/lib/crawler/dsl/link_extractor.rb
+++ b/lib/crawler/dsl/link_extractor.rb
@@ -1,0 +1,27 @@
+module Crawler
+  module Dsl
+    class LinkExtractor
+      include DslOrganizer::ExportCommand[:extract_links_for]
+
+      def call(url, path = false)
+        crawler.extract_links(url: url, only_path: path)
+        crawler.report_save
+      end
+
+      def crawler
+        @crawler ||= Crawler::Engine.new(options)
+      end
+
+      private
+
+      def options
+        configuration = DslOrganizer::CommandContainer[:configuration]
+        if configuration
+          DslOrganizer::CommandContainer[:configuration].options
+        else
+          Configuration::DEFAULT_OPTIONS
+        end
+      end
+    end
+  end
+end

--- a/lib/crawler/dsl/visit_command.rb
+++ b/lib/crawler/dsl/visit_command.rb
@@ -1,0 +1,17 @@
+require 'capybara'
+require 'capybara-screenshot'
+
+module Crawler
+  module Dsl
+    class VisitCommand
+      include DslOrganizer::ExportCommand[:visit_to]
+      include ::Capybara::DSL
+
+      def call(target_url)
+        uri = URI(target_url.to_s)
+        Capybara.app_host = "#{uri.scheme}://#{uri.host}:#{uri.port}"
+        visit uri.path
+      end
+    end
+  end
+end

--- a/lib/crawler/hooks_operator.rb
+++ b/lib/crawler/hooks_operator.rb
@@ -1,0 +1,34 @@
+module Crawler
+  module HooksOperator
+
+      def with_hooks_for_each_page
+        run_before_hooks(type: :each)
+        yield
+        run_after_hooks(type: :each)
+      end
+
+      def with_hooks_for_all_pages
+        run_before_hooks(type: :all)
+        yield
+        run_after_hooks(type: :all)
+      end
+
+      private
+
+      def run_before_hooks(type:)
+        before_hook = DslOrganizer::CommandContainer[:before]
+        return unless before_hook
+        run_hooks(before_hook.hooks[type])
+      end
+
+      def run_after_hooks(type:)
+        after_hook = DslOrganizer::CommandContainer[:after]
+        return unless after_hook
+        run_hooks(after_hook.hooks[type])
+      end
+
+      def run_hooks(hooks)
+        hooks.each {|hook| instance_exec(&hook)}
+      end
+  end
+end

--- a/lib/crawler/reports/simple.rb
+++ b/lib/crawler/reports/simple.rb
@@ -44,7 +44,7 @@ module Crawler
       end
 
       def to_h
-        {}.merge(@pages)
+        {}.merge(pages: @pages)
           .merge(@metadata)
           .merge({started_at: @started_at, finished_at: @finished_at})
       end

--- a/lib/crawler/version.rb
+++ b/lib/crawler/version.rb
@@ -1,3 +1,3 @@
 module Crawler
-  VERSION = "0.1.1"
+  VERSION = "0.2.1"
 end

--- a/spec/crawler_spec.rb
+++ b/spec/crawler_spec.rb
@@ -1,4 +1,3 @@
-
 require 'spec_helper'
 require 'rack'
 
@@ -93,43 +92,6 @@ describe Crawler do
       extracted_links = crawler.report.pages['/'][:extracted_links]
 
       expect(extracted_links).to eq([])
-    end
-
-    it 'overwrites before_crawling callback method and executes it' do
-      Capybara.server = :webrick
-      Capybara::Server.new(app).boot
-      url = "http://#{server.host}:#{server.port}/"
-
-      crawler = Crawler::Engine.new(max_pages: 1)
-
-      crawler.overwrite_callback(method: :before_crawling) do
-        @report.record_page_visit(page: '/before_crawling', extracted_links: ['link1'])
-      end
-
-      crawler.extract_links(url: url)
-
-      extracted_links = crawler.report.pages['/before_crawling'][:extracted_links]
-
-      expect(extracted_links).to eq(['link1'])
-    end
-
-
-    it 'overwrites after_crawling callback method and executes it' do
-      Capybara.server = :webrick
-      Capybara::Server.new(app).boot
-      url = "http://#{server.host}:#{server.port}/"
-
-      crawler = Crawler::Engine.new(max_pages: 1)
-
-      crawler.overwrite_callback(method: :after_crawling) do
-        @report.record_page_visit(page: '/after_crawling', extracted_links: ['link1'])
-      end
-
-      crawler.extract_links(url: url)
-
-      extracted_links = crawler.report.pages['/after_crawling'][:extracted_links]
-
-      expect(extracted_links).to eq(['link1'])
     end
   end
 end

--- a/spec/dsl_spec.rb
+++ b/spec/dsl_spec.rb
@@ -1,0 +1,20 @@
+require 'spec_helper'
+require 'rack'
+
+describe Crawler::Dsl do
+  it 'starts crawling with the path provided in the url' do
+    fixture_path = File.expand_path('fixtures/static_site', __dir__)
+    app = Rack::Builder.app do
+      use Rack::Static, urls: {'/' => 'index.html'}, root: fixture_path
+      run Rack::File.new(fixture_path)
+    end
+    Capybara.server = :webrick
+    server = Capybara::Server.new(app).boot
+
+    expect_any_instance_of(Crawler::Dsl::LinkExtractor).to receive(:call)
+
+    Crawler.run do
+      extract_links_for(url: "http://#{server.host}:#{server.port}/")
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,3 @@
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require 'crawler'
-require 'pry'
+require 'byebug'


### PR DESCRIPTION
add a dsl syntax with follow commands:
-  before; 
-  after; 
-   configuration;
-   visit_to;
-   extraxt_links_for;

the example shows as it can be used:
```ruby
require 'crawler'

Crawler.run do
  configuration do |conf|
    conf.max_pages 10
  end

  before :all do
    visit_to 'https://www.epam.com/'
    within('.top-navigation-ui') do
      click_on 'Careers'
    end
    page.find('h2' ,text:'Find your dream job')
  end

  extract_links_for('https://www.rwpod.com/')
end
```