### PR TITLE
fix csv report

### DIFF
--- a/lib/browser_crawler/reports/csv_report.rb
+++ b/lib/browser_crawler/reports/csv_report.rb
@@ -13,6 +13,8 @@ module BrowserCrawler
           csv << ['pages', 'extracted links']
 
           @store.pages.each do |page, crawler_result|
+            next if crawler_result[:extracted_links].nil?
+
             crawler_result[:extracted_links].each do |link|
               csv << [page, link]
             end

--- a/lib/browser_crawler/reports/csv_report.rb
+++ b/lib/browser_crawler/reports/csv_report.rb
@@ -13,7 +13,10 @@ module BrowserCrawler
           csv << ['pages', 'extracted links']
 
           @store.pages.each do |page, crawler_result|
-            next if crawler_result[:extracted_links].nil?
+            if crawler_result[:extracted_links].nil?
+              csv << [page, nil]
+              next
+            end
 
             crawler_result[:extracted_links].each do |link|
               csv << [page, link]

--- a/lib/browser_crawler/version.rb
+++ b/lib/browser_crawler/version.rb
@@ -1,3 +1,3 @@
 module BrowserCrawler
-  VERSION = "0.2.1"
+  VERSION = "0.2.2"
 end

--- a/spec/lib/reports/csv_report_spec.rb
+++ b/spec/lib/reports/csv_report_spec.rb
@@ -16,7 +16,7 @@ describe BrowserCrawler::Reports::CsvReport do
                                                        '/login'
                                                      ]
                                                    },
-                                                   '/fail': {
+                                                   '/blank': {
                                                      extracted_links: nil
                                                    }
                                                  }, metadata: {})
@@ -36,7 +36,8 @@ describe BrowserCrawler::Reports::CsvReport do
                                   ['/', '/help'],
                                   ['/', '/search'],
                                   ['/home', '/'],
-                                  ['/home', '/login']])
+                                  ['/home', '/login'],
+                                  ['/blank', nil]])
       end
     end
   end

--- a/spec/lib/reports/csv_report_spec.rb
+++ b/spec/lib/reports/csv_report_spec.rb
@@ -15,6 +15,9 @@ describe BrowserCrawler::Reports::CsvReport do
                                                        '/',
                                                        '/login'
                                                      ]
+                                                   },
+                                                   '/fail': {
+                                                     extracted_links: nil
                                                    }
                                                  }, metadata: {})
 


### PR DESCRIPTION
if crawler can not extract links from a page, it will raise an exception when a store converts to a csv report.