### PR TITLE
Exclude empty link from report

### DIFF
--- a/lib/browser_crawler/engine.rb
+++ b/lib/browser_crawler/engine.rb
@@ -102,7 +102,7 @@ module BrowserCrawler
 
     def remove_blank_links(links)
       links.reject do |link|
-        link.nil? || link == ''
+        link.nil? || link.empty?
       end
     end
 

--- a/lib/browser_crawler/engine.rb
+++ b/lib/browser_crawler/engine.rb
@@ -97,8 +97,12 @@ module BrowserCrawler
     private
 
     def get_page_links
-      page.all('a').map do |a|
-        a['href']
+      remove_blank_links(page.all('a').map { |a| a['href']})
+    end
+
+    def remove_blank_links(links)
+      links.reject do |link|
+        link.nil? || link == ''
       end
     end
 

--- a/spec/browser_crawler_spec.rb
+++ b/spec/browser_crawler_spec.rb
@@ -74,6 +74,15 @@ describe BrowserCrawler do
     expect(unrecognized_links.include?('mailto:example@com')).to be true
   end
 
+  it 'excludes empty links from report' do
+    crawler = BrowserCrawler::Engine.new
+    crawler.extract_links(url: "#{url}page5.html")
+
+    extracted_links = crawler.report_store
+                             .pages['/page5.html'][:extracted_links]
+    expect(extracted_links).to eql []
+  end
+
   context 'change Capybara driver' do
     let(:app) do
       fixture_path = File.expand_path('fixtures/static_site', __dir__)

--- a/spec/fixtures/static_site/page5.html
+++ b/spec/fixtures/static_site/page5.html
@@ -1,0 +1,7 @@
+<html>
+<head></head>
+<body>
+<a href="">#</a>
+<a>#</a>
+</body>
+</html>


### PR DESCRIPTION
For the example html:
```
<html>
<head></head>
<body>
   <a href="/1234">#</a>
  <a href="">#</a>
  <a>#</a>
</body>
</html>
```
a report consists of only ['/1234']

