### PR TITLE
fix/GH-19 fix csv report structure

### DIFF
--- a/lib/browser_crawler/reports/csv_report.rb
+++ b/lib/browser_crawler/reports/csv_report.rb
@@ -10,7 +10,11 @@ module BrowserCrawler
 
       def export(save_folder_path:)
         CSV.open("#{save_folder_path}/crawler_report.csv", 'wb') do |csv|
-          csv << csv_header
+          csv << ['pages',
+                  'extracted links',
+                  'is external',
+                  'http status',
+                  'http code']
 
           @store.pages.each do |page, crawler_result|
             save_to_csv(csv, page, crawler_result)
@@ -39,7 +43,7 @@ module BrowserCrawler
       def save_to_csv(csv, page, crawler_result)
         extracted_links = filter_links(crawler_result[:extracted_links])
 
-        if extracted_links.nil?
+        if extracted_links.nil? || extracted_links.empty?
           csv << save_to_row(page, crawler_result)
           return
         end

--- a/lib/browser_crawler/version.rb
+++ b/lib/browser_crawler/version.rb
@@ -1,3 +1,3 @@
 module BrowserCrawler
-  VERSION = "0.3.3"
+  VERSION = "0.3.4"
 end


### PR DESCRIPTION
I have implemented the csv report service that removes all links with an empty external_links array. This PR is fixed this behavior. 